### PR TITLE
Feature/add force support

### DIFF
--- a/jablotronpy/jablotronpy.py
+++ b/jablotronpy/jablotronpy.py
@@ -328,13 +328,14 @@ class Jablotron:
         raise UnexpectedResponse("Unable to retrieve event history.")
 
     def control_component(self, service_id: int, component_id: str, state: str, control_pg: bool = False,
-                          service_type: str = "JA100"):
+                          service_type: str = "JA100", force: bool = False):
         """
         :param service_id: ID of your service, this ID can be obtained from get_services()
         :param service_type: Type of your service, type can be obtained from output of get_services()
         :param component_id:
         :param control_pg:
         :param state: For a section use either ARM or DISARM, for a PG use ON or OFF
+        :param force: Overwrite a blockage of the component
         :return:
         """
         if control_pg is True:
@@ -351,7 +352,8 @@ class Jablotron:
             "authorization": {"authorization-code": f"{self.pin_code}"},
             "control-components": [{
                 "actions": dict(action=control_type, value=state.upper()),
-                "component-id": component_id
+                "component-id": component_id,
+                "force": force
             }]
         }
 
@@ -365,7 +367,7 @@ class Jablotron:
                 if component["component-id"] == component_id and component["state"] == state.upper():
                     return component
 
-        raise UnexpectedResponse("Unable to control component")
+        raise UnexpectedResponse(f"Unable to control component, response: {data}")
 
     def control_programmable_gate(self, service_id: int, component_id: str, on: bool):
         """

--- a/tests/test_jablotron.py
+++ b/tests/test_jablotron.py
@@ -35,7 +35,7 @@ class TestJablotron(TestCase):
 
     def test_control_programmable_gate(self):
         service_id = self.jablotron.get_services()[1]["service-id"]
-        pg_id = self.jablotron.get_programmable_gates(service_id=service_id)["states"][15]["cloud-component-id"]
+        pg_id = self.jablotron.get_programmable_gates(service_id=service_id)["states"][1]["cloud-component-id"]
         data = self.jablotron.control_programmable_gate(service_id=service_id, component_id=pg_id, on=False)
         assert data["component-id"] == pg_id
         assert data["state"] == "OFF"


### PR DESCRIPTION
This pull request to `jablotronpy` includes changes to enhance the control component functionality and improve error messaging. The most important changes include adding a `force` parameter to the `control_component` method, updating the error message for component control failures, and modifying a test case for programmable gates.

Enhancements to control component functionality:

* [`jablotronpy/jablotronpy.py`](diffhunk://#diff-ed4e2530eb15904fe570e7d92b64cb56a5c2f4a06d3d153540238c429788a919L331-R338): Added a `force` parameter to the `control_component` method to allow overwriting blockages of components. (`[[1]](diffhunk://#diff-ed4e2530eb15904fe570e7d92b64cb56a5c2f4a06d3d153540238c429788a919L331-R338)`, `[[2]](diffhunk://#diff-ed4e2530eb15904fe570e7d92b64cb56a5c2f4a06d3d153540238c429788a919L354-R356)`)

Improvements to error messaging:

* [`jablotronpy/jablotronpy.py`](diffhunk://#diff-ed4e2530eb15904fe570e7d92b64cb56a5c2f4a06d3d153540238c429788a919L368-R370): Updated the error message in the `control_component` method to include the response data when unable to control a component. (`[jablotronpy/jablotronpy.pyL368-R370](diffhunk://#diff-ed4e2530eb15904fe570e7d92b64cb56a5c2f4a06d3d153540238c429788a919L368-R370)`)

Test case modifications:

* [`tests/test_jablotron.py`](diffhunk://#diff-c6724a099c80c2587afe85966467e7eb4af3dc533ffba0f15b818b468d9b0d90L38-R38): Modified the `test_control_programmable_gate` method to use the correct index for retrieving the programmable gate ID. (`[tests/test_jablotron.pyL38-R38](diffhunk://#diff-c6724a099c80c2587afe85966467e7eb4af3dc533ffba0f15b818b468d9b0d90L38-R38)`)