### PR TITLE
New methods for getting a service settings, a device schedule and controlling a thermo device

### DIFF
--- a/jablotronpy/jablotronpy.py
+++ b/jablotronpy/jablotronpy.py
@@ -179,19 +179,23 @@ class Jablotron:
         states = data.get("states", [])
         devices = data.get("thermo-devices", [])
 
-        meta_by_id = {d["object-device-id"]: d for d in devices}
+        device_by_id = {d["object-device-id"]: d for d in devices}
 
         result: list[JablotronThermoDevice] = []
 
         for state in states:
             dev_id = state["object-device-id"]
-            meta = meta_by_id.get(dev_id, {})
-            result.append({
-                "object-device-id": dev_id,
-                "temperature": state.get("temperature"),
-                "last-temperature-time": state.get("last-temperature-time"),
-                "name": meta.get("name", "")
-            })
+            meta = device_by_id.get(dev_id, {})
+            result.append(
+                {
+                    "object-device-id": dev_id,
+                    "name": meta.get("name", ""),
+                    "temperature": state.get("temperature"),
+                    "last-temperature-time": state.get("last-temperature-time"),
+                    "thermo-device": device_by_id.get(dev_id, {}),
+                    "state": state,
+                }
+            )
 
         return result
 
@@ -354,3 +358,109 @@ class Jablotron:
         # Validate that control action was successful
         response_data: JablotronProgrammableGateControlResponse = response.json().get("data", {})
         return self._was_control_action_successful(response_data, component_id, state)
+
+    def get_service_settings(
+        self, service_id: int, service_type: str = "JA100"
+    ) -> JablotronServiceInformation:
+        """
+        Return information about settings for a service.
+
+        :param service_id: id of service to get settings for
+        :param service_type: type of service to get settings for
+        """
+
+        response = self._send_request(
+            endpoint="getServiceSettings.json",
+            payload={"serviceId": service_id, "service": service_type.lower()},
+        )
+
+        return response.json()
+
+    def control_thermo_device(
+        self,
+        service_id: int,
+        object_device_id: str,
+        heating_mode: Literal["MANUAL", "SCHEDULED", "OFF", "ON"],
+        service_type: str = "JA100",
+    ) -> bool:
+        """
+        Set thermo device of specified service to desired heating mode.
+
+        :param service_id: id of service to control thermo device for
+        :param object_device_id: id of thermo device to control
+        :param heating_mode: heating mode to set
+        :param service_type: type of service to control thermo device for
+        """
+
+        response = self._send_request(
+            endpoint=f"{service_type}/controlThermoDevice.json",
+            payload={
+                "service-id": service_id,
+                "control-components": [
+                    {
+                        "actions": {"set-heating-mode": heating_mode},
+                        "component-id": object_device_id,
+                    }
+                ],
+            },
+        )
+
+        response_body = response.json()
+        response_data = response_body.get("data", {})
+
+        for error in response_data.get("control-errors", []):
+            raise ControlActionException(
+                "Control action failed with unexpected error.", error
+            )
+
+        states = response_data.get("states", [])
+        state = next(
+            filter(lambda state: state["object-device-id"] == object_device_id, states),
+            None,
+        )
+
+        if state is None:
+            return False
+
+        # When changing heating mode to OFF reply contains STAND_BY mode.
+        # When changing heating mode to ON reply contains either MANUAL or SCHEDULED mode.
+        return (
+            heating_mode == state["mode"]
+            or (heating_mode == "OFF" and state["mode"] == "STAND_BY")
+            or (
+                heating_mode == "ON"
+                and (state["mode"] == "MANUAL" or state["mode"] == "SCHEDULED")
+            )
+        )
+
+    def get_device_schedule(
+        self,
+        service_id: str,
+        device_type: str,
+        device_id: str,
+        room_id: str,
+        service_type: str = "JA100",
+    ):
+        """
+        Return information about a schedule
+
+        :param service_id: id of service to get schedule for
+        :param device_type: device_type to get schedule for
+        :param device_id: device_id to get schedule for
+        :param room_id: room_id to get schedule for
+        :param service_type: type of service to get schedule for
+        """
+
+        response = self._send_request(
+            endpoint="getDeviceSchedule.json",
+            payload={
+                "status": True,
+                "type": device_type,
+                "id": device_id,
+                "parent_type": service_type.lower(),
+                "room_id": room_id,
+                "parent_id": service_id,
+            },
+        )
+
+        return response.json()

--- a/jablotronpy/jablotronpy.py
+++ b/jablotronpy/jablotronpy.py
@@ -8,7 +8,7 @@ from jablotronpy.exceptions import BadRequestException, UnauthorizedException, S
     ControlActionException
 from jablotronpy.types import JablotronService, JablotronServiceInformation, JablotronSections, JablotronThermoDevice, \
     JablotronKeyboard, JablotronProgrammableGates, JablotronServiceHistoryEvent, JablotronSectionControlResponse, \
-    JablotronProgrammableGateControlResponse, JablotronDeviceSchedule
+    JablotronProgrammableGateControlResponse, JablotronDeviceSchedule, JablotronServiceSettings
 
 
 class Jablotron:
@@ -361,7 +361,7 @@ class Jablotron:
 
     def get_service_settings(
         self, service_id: int, service_type: str = "JA100"
-    ) -> JablotronServiceInformation:
+    ) -> JablotronServiceSettings:
         """
         Return information about settings for a service.
 
@@ -374,7 +374,8 @@ class Jablotron:
             payload={"serviceId": service_id, "service": service_type.lower()},
         )
 
-        return response.json()
+        response_data: JablotronServiceSettings = response.json()
+        return response_data
 
     def control_thermo_device(
         self,

--- a/jablotronpy/jablotronpy.py
+++ b/jablotronpy/jablotronpy.py
@@ -8,7 +8,7 @@ from jablotronpy.exceptions import BadRequestException, UnauthorizedException, S
     ControlActionException
 from jablotronpy.types import JablotronService, JablotronServiceInformation, JablotronSections, JablotronThermoDevice, \
     JablotronKeyboard, JablotronProgrammableGates, JablotronServiceHistoryEvent, JablotronSectionControlResponse, \
-    JablotronProgrammableGateControlResponse
+    JablotronProgrammableGateControlResponse, JablotronDeviceSchedule
 
 
 class Jablotron:
@@ -440,7 +440,7 @@ class Jablotron:
         device_id: str,
         room_id: str,
         service_type: str = "JA100",
-    ):
+    ) -> JablotronDeviceSchedule:
         """
         Return information about a schedule
 
@@ -463,4 +463,5 @@ class Jablotron:
             },
         )
 
-        return response.json()
+        response_data: JablotronDeviceSchedule = response.json()
+        return response_data

--- a/jablotronpy/types.py
+++ b/jablotronpy/types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, Union
 
 # ==================
 # ==== SERVICES ====
@@ -253,5 +253,48 @@ JablotronProgrammableGateControlResponse = TypedDict(
     {
         "control-errors": list[JablotronSectionControlResponseError] | None,
         "states": list[JablotronSectionControlResponseState]
+    }
+)
+
+# =========================
+# ==== DEVICE SCHEDULE ====
+# =========================
+
+JablotronDeviceScheduleDataEntry = TypedDict(
+    "JablotronDeviceScheduleDataEntry",
+    {
+        "id": str,
+        "value": str,
+        "day": str,
+        "start": int,
+        "end": int
+    }
+)
+
+JablotronDeviceScheduleEntry = TypedDict(
+    "JablotronDeviceScheduleEntry",
+    {
+        "room_id": str,
+        "programs": list[str],
+        "group_by": str,
+        "default": str,
+        "restrict_count": int,
+        "restrict_count_interval": str,
+        "data": list[JablotronDeviceScheduleDataEntry]
+    }
+)
+
+JablotronDeviceSchedule = TypedDict(
+    "JablotronDeviceSchedule",
+    {
+        "id": str,
+        "type": str,
+        "parent_id": int,
+        "parent_type": str,
+        "schedule": list[JablotronDeviceScheduleEntry],
+        "status": bool,
+        "checksum": str,
+        "server_id": str,
+        "client_id": Union[None, str]
     }
 )

--- a/jablotronpy/types.py
+++ b/jablotronpy/types.py
@@ -298,3 +298,88 @@ JablotronDeviceSchedule = TypedDict(
         "client_id": Union[None, str]
     }
 )
+
+# ==========================
+# ==== SERVICE SETTINGS ====
+# ==========================
+
+JablotronServiceInformationDevice = TypedDict(
+    "JablotronServiceInformationDevice",
+    {
+        "family": str,
+        "model-name": str,
+        "service-name": str,
+        "registration-key": str,
+        "registration-date": str,
+        "phone-number": str,
+        "firmware": str,
+    }
+)
+
+JablotronServiceInformationInstallationCompany = TypedDict(
+    "JablotronServiceInformationInstallationCompany",
+    {
+        "name": str,
+        "phone-number": str,
+        "email": str
+    }
+)
+
+JablotronServiceSettingsNamesEntry = TypedDict(
+    "JablotronServiceSettingsNamesEntry",
+    {
+        "name_type": str,
+        "name_key": str,
+        "name_value": str
+    }
+)
+
+JablotronServiceSettingsThermostatSettingsPrograms = TypedDict(
+    "JablotronServiceSettingsThermostatSettingsPrograms",
+    {
+        "temp_economy": float,
+        "temp_comfort": float,
+        "temp_turned_off": float,
+    }
+)
+
+JablotronServiceSettingsThermostatSettings = TypedDict(
+    "JablotronServiceSettingsThermostatSettings",
+    {
+        "temperature_limits_editable": bool,
+        "hysteresis": float,
+        "calibration_offset": float,
+        "temp_min": float,
+        "temp_max": float,
+        "programs": JablotronServiceSettingsThermostatSettingsPrograms
+    }
+)
+
+JablotronServiceSettingsThermostatsEntry = TypedDict(
+    "JablotronServiceSettingsThermostatsEntry",
+    {
+        "object_id": str,
+        "thermostat_index": str,
+        "object-device-id": str,
+        "thermostat_name": str,
+        "type": str,
+        "settings": JablotronServiceSettingsThermostatSettings
+    }
+)
+
+JablotronServiceSettings = TypedDict(
+    "JablotronServiceSettings",
+    {
+        "status": bool,
+        "settings_service_index": int,
+        "settings_service_visible": bool,
+        "settings_change_registration": bool,
+        "settings_names": list[JablotronServiceSettingsNamesEntry],
+        "permissions": None,
+        "settings_lite_plus_allowed": bool,
+        "thermostats": list[JablotronServiceSettingsThermostatsEntry],
+        "checksum": str,
+        "server_id": str,
+        "client_id": Union[None, str]
+    }
+)


### PR DESCRIPTION
I've implemented couple of new endpoints mainly to help with controlling thermo devices as described in #28. Tests are not included in the PR, I will add them when we agree this looks good.

- [ ] Add tests for new endpoints

## Changes
- Change `get_thermo_devices` to return `thermo-device` and `state` fields with data directly from the API
- Add `get_service_settings` to get service settings
- Add `control_thermo_device` to be able to control thermo devices
- Add `get_device_schedule` to get device schedule (i.e. thermostat schedule)

## Example
<details>
<summary>Example code using the new endpoints</summary>

```python
import os
from pprint import pp

from jablotronpy.jablotronpy import Jablotron


def main():
    client = Jablotron(
        username=os.environ["JABLOTRON_USER"],
        password=os.environ["JABLOTRON_PASS"],
        pin_code=os.environ["JABLOTRON_PIN"],
    )
    client.perform_login()

    services = client.get_services()
    service_id = service_id = services[0]["service-id"]
    service_type = "JA100F"

    thermo_devices = client.get_thermo_devices(service_id=service_id, service_type=service_type)
    pp(["thermo_devices", thermo_devices])
    print()

    service_settings = client.get_service_settings(service_id=service_id, service_type=service_type)
    pp(["service_settings", service_settings])
    print()

    thermostat = next(
        filter(
            lambda device: device["thermo-device"]["type"] == "THERMOSTAT",
            thermo_devices,
        ),
        None,
    )
    pp(["thermostat", thermostat])
    print()

    pp(
        [
            "thermostat set",
            client.control_thermo_device(
                service_id=service_id,
                object_device_id=thermostat["object-device-id"],
                heating_mode="OFF",
                service_type=service_type,
            ),
        ]
    )
    print()

    thermostat_settings = next(
        filter(
            lambda th: th["object-device-id"] == thermostat["object-device-id"],
            service_settings.get("thermostats", []),
        ),
        None,
    )

    schedule = client.get_device_schedule(
        service_id=service_id,
        device_type="ja100-thermostat",
        device_id=f"{thermostat_settings['object_id']}.0",
        room_id=f"{thermostat_settings['thermostat_index']}.0",
        service_type=service_type,
    )
    pp(["schedule", schedule])


if __name__ == "__main__":
    main()

```
</details>

## Goal
My goal is to get this implemented in https://github.com/Pigotka/ha-cc-jablotron-cloud as well. I would like to be able to create a custom heating schedule in HA to control the thermostat based home presence and other thermometers I have connected to HA. And also to see the heating state (ON/OFF) in the HA.