### PR TITLE
Implement setting thermo device temperature in `control_thermo_device`

### DIFF
--- a/jablotronpy/types.py
+++ b/jablotronpy/types.py
@@ -118,13 +118,46 @@ JablotronSections = TypedDict(
 # ==== THERMO DEVICES ====
 # ========================
 
-JablotronThermoDevice = TypedDict(
-    "JablotronThermoDevice",
+JablotronThermoDeviceDetails = TypedDict(
+    "JablotronThermoDeviceDetails",
+    {
+        "object-device-id": str,
+        "cloud-entity-id": str,
+        "name": str,
+        "can-control": bool,
+        "can-show-graph": bool,
+        "unit": str,
+        "type": str,
+        "temperature-range-min": float,
+        "temperature-range-max": float
+    }
+)
+
+JablotronThermoDeviceState = TypedDict(
+    "JablotronThermoDeviceState",
     {
         "object-device-id": str,
         "temperature": float,
         "last-temperature-time": str,
-        "name": str
+        "temperature-set": float,
+        "mode": str,
+        "temperature-comfort": float,
+        "temperature-economic": float,
+        "next-temperature-change": str,
+        "next-temperature-mode": str,
+        "heating-state": str
+    }
+)
+
+JablotronThermoDevice = TypedDict(
+    "JablotronThermoDevice",
+    {
+        "object-device-id": str,
+        "name": str,
+        "temperature": float,
+        "last-temperature-time": str,
+        "thermo-device": JablotronThermoDeviceDetails,
+        "state": JablotronThermoDeviceState,
     }
 )
 


### PR DESCRIPTION
With this PR thermo device temperature can be set using `control_thermo_device_with_response` or `control_thermo_device` methods with `temperature` parameter.

## Changes
- Add `control_thermo_device_with_response` to make it possible to get the state after device state is changed
- Add `temperature` argument to `control_thermo_device`

## Goal
Make it possible to control the heating temperature and use the updated state after the API call is finished to update the HA integration (work in progress).