### PR TITLE
Implement update_service_settings for updating thermostat settings

### DIFF
--- a/jablotronpy/types.py
+++ b/jablotronpy/types.py
@@ -418,3 +418,15 @@ JablotronServiceSettings = TypedDict(
         "client_id": str | None,
     },
 )
+
+JablotronServiceSettingsUpdateResponse = TypedDict(
+    "JablotronServiceSettingsUpdateResponse",
+    {
+        "status": bool,
+        "checksum": str,
+        "server_id": str,
+        "client_id": str | None,
+        "error_status": str | None,
+        "error_message": str | None,
+    },
+)


### PR DESCRIPTION
~~**I've marked this PR as Draft because it builds on #32.**~~

With this PR thermostat settings can be changed using `update_service_settings` method with `thermostat_settings` parameter.

# Changes
- Add `update_service_settings` method to make it possible to change thermostat settings.
- Add `send_request_with_form_data` to be able to send request with `application/x-www-form-urlencoded` content type as `updateServiceSettings.json` does not work with JSON content type.

# Goal
Make it possible to update thermostat settings like comfort, eco and turned off temperatures, hysteresis and calibration_offset.

After merging this PR, #28 can be closed as all methods to control thermostat and its settings will be implemented.